### PR TITLE
Add partial support for running Scala Native tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,31 @@
 language: scala
 scala:
   - 2.11.11
-  - 2.12.4
+  - 2.12.8
 jdk:
   - oraclejdk8
 
-script:
-  sbt ++$TRAVIS_SCALA_VERSION tomlJS/test tomlJVM/test
+dist: trusty
+sudo: required
 
-# From http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
-# Use container-based infrastructure
-sudo: false
+addons:
+  apt:
+    update: true
+
 # These directories are cached to S3 at the end of the build
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt
+    - $HOME/.sbt/boot
+
+# From https://raw.githubusercontent.com/scalalandio/chimney/master/.travis.yml
+before_script:
+  - if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x; fi
+
+script:
+  - if [[ "$TRAVIS_SCALA_VERSION" == 2.11.* ]]; then testNative=tomlNative/test; else testNative=""; fi && sbt ++$TRAVIS_SCALA_VERSION tomlJVM/test tomlJS/test $testNative
+
 before_cache:
-  # Cleanup the cached directories to avoid unnecessary cache updates
+  # Clean up the cached directories to avoid unnecessary cache updates
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt        -name "*.lock"               -print -delete

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ toml-scala is a feature-complete implementation of [TOML](https://github.com/tom
 - Property-based unit tests
 
 ## Compatibility
-| Back end   | Scala versions | Date support | Tests  |
-|:-----------|:---------------|:-------------|:-------|
-| JVM        | 2.11, 2.12     | Yes          | Yes    |
-| JavaScript | 2.11, 2.12     | No (1)       | Yes    |
-| LLVM       | 2.11           | No (1)       | No (2) |
+| Back end   | Scala versions | Date support | Tests         |
+|:-----------|:---------------|:-------------|:--------------|
+| JVM        | 2.11, 2.12     | Yes          | Yes           |
+| JavaScript | 2.11, 2.12     | No (1)       | Yes           |
+| LLVM       | 2.11           | No (1)       | Partially (2) |
 
 * (1) JavaScript and LLVM have insufficient support for the JDK8's `java.time`. Parsing of dates and times is presently only possible under the JVM.
-* (2) Presently, Scala Native does not support running ScalaTest/ScalaCheck test suites.
+* (2) Presently, Scala Native does not support running ScalaCheck test suites.
 
 ### Dependencies
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,14 @@
-// Shadow sbt-scalajs' crossProject and CrossType until Scala.js 1.0.0 is released
-import sbtcrossproject.{crossProject, CrossType}
+// shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 val Scala2_11  = "2.11.12"
-val Scala2_12  = "2.12.4"
+val Scala2_12  = "2.12.8"
 val FastParse  = "1.0.0"
 val Shapeless  = "2.3.3"
 val Paradise   = "2.1.1"
-val ScalaCheck = "1.13.5"
-val ScalaTest  = "3.0.4"
+val ScalaCheck = "1.14.0"
+val ScalaTest  = "3.0.5"
+val ScalaTestNative = "3.2.0-SNAP10"
 
 val SharedSettings = Seq(
   name         := "toml-scala",
@@ -36,10 +37,8 @@ val SharedSettings = Seq(
     </developers>
 )
 
-enablePlugins(ScalaNativePlugin)
-
 lazy val root = project.in(file("."))
-  .aggregate(tomlJS, tomlJVM, tomlNative)
+  .aggregate(toml.js, toml.jvm, toml.native)
   .settings(SharedSettings: _*)
   .settings(skip in publish := true)
 
@@ -68,9 +67,10 @@ lazy val toml =
     .nativeSettings(
       scalaVersion       := Scala2_11,
       crossScalaVersions := Seq(Scala2_11),
-      excludeFilter in Test := "*"
+      // See https://github.com/scalalandio/chimney/issues/78#issuecomment-419705142
+      nativeLinkStubs    := true,
+      libraryDependencies ++= Vector(
+        "org.scalatest" %%% "scalatest" % ScalaTestNative  % "test"
+      ),
+      excludeFilter in Test := "*GeneratedSpec*" || "*Generators*"
     )
-
-lazy val tomlJS     = toml.js
-lazy val tomlJVM    = toml.jvm
-lazy val tomlNative = toml.native

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.4
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scala-js"      % "sbt-scalajs"              % "0.6.21")
-addSbtPlugin("org.scala-native"  % "sbt-crossproject"         % "0.2.2" )
-addSbtPlugin("org.scala-native"  % "sbt-scalajs-crossproject" % "0.2.2" )
-addSbtPlugin("org.scala-native"  % "sbt-scala-native"         % "0.3.6" )
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.26")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.8")

--- a/shared/src/test/scala/toml/GenerationSpec.scala
+++ b/shared/src/test/scala/toml/GenerationSpec.scala
@@ -229,14 +229,19 @@ class GenerationSpec extends FunSuite {
   }
 
   test("Encoding positive real value") {
-    val root = Root(List(Pair("a", Real(100.12))))
-    val result = """a = 100.12"""
-    check(root, result)
+    // See https://github.com/scala-native/scala-native/pull/1298
+    if (System.getProperty("java.vm.name") != "Scala Native") {
+      val root = Root(List(Pair("a", Real(100.12))))
+      val result = """a = 100.12"""
+      check(root, result)
+    }
   }
 
   test("Encoding negative real value") {
-    val root = Root(List(Pair("a", Real(-100.12))))
-    val result = """a = -100.12"""
-    check(root, result)
+    if (System.getProperty("java.vm.name") != "Scala Native") {
+      val root = Root(List(Pair("a", Real(-100.12))))
+      val result = """a = -100.12"""
+      check(root, result)
+    }
   }
 }


### PR DESCRIPTION
Currently, only ScalaTest suites are supported. Also bump all
dependencies except for FastParse which does not support Scala
Native anymore in the latest version.