### PR TITLE
Rules: Fix parsing of floating point numbers

### DIFF
--- a/shared/src/test/scala/toml/RulesSpec.scala
+++ b/shared/src/test/scala/toml/RulesSpec.scala
@@ -131,4 +131,76 @@ class RulesSpec extends FunSuite with Matchers {
     val example = "number = 3.14  p"
     testFailure(example)
   }
+
+  test("Parse floats with fractional part") {
+    val example =
+      """flt1 = +1.0
+        |flt2 = 3.1415
+        |flt3 = -0.01
+      """.stripMargin
+
+    assert(testSuccess(example) == Root(List(
+      Node.Pair("flt1", Value.Real(+1.0)),
+      Node.Pair("flt2", Value.Real(3.1415)),
+      Node.Pair("flt3", Value.Real(-0.01)))))
+  }
+
+  test("Parse floats with exponent part") {
+    val example =
+      """flt4 = 5e+22
+        |flt5 = 1e6
+        |flt6 = -2E-2
+      """.stripMargin
+
+    assert(testSuccess(example) == Root(List(
+      Node.Pair("flt4", Value.Real(5e+22)),
+      Node.Pair("flt5", Value.Real(1e6)),
+      Node.Pair("flt6", Value.Real(-2E-2)))))
+  }
+
+  test("Parse floats with fractional and exponent part") {
+    val example = "flt7 = 6.626e-34\n" +
+                  "poly = -45.321e12"
+
+    assert(testSuccess(example) == Root(List(
+      Node.Pair("flt7", Value.Real(6.626e-34)),
+      Node.Pair("poly", Value.Real(-45.321e12)))))
+  }
+
+  test("Parse floats with underscores") {
+    val example = "flt8 = 224_617.445_991_228"
+
+    assert(testSuccess(example) == Root(List(
+      Node.Pair("flt8", Value.Real(224617.445991228)))))
+  }
+
+  test("Parse infinity constant") {
+    val example =
+      """sf1 = inf
+        |sf2 = +inf
+        |sf3 = -inf
+        |""".stripMargin
+
+    assert(testSuccess(example) == Root(List(
+      Node.Pair("sf1", Value.Real(Double.PositiveInfinity)),
+      Node.Pair("sf2", Value.Real(Double.PositiveInfinity)),
+      Node.Pair("sf3", Value.Real(Double.NegativeInfinity)))))
+  }
+
+  test("Parse NaN constant") {
+    val example =
+      """sf4 = nan
+        |sf5 = +nan
+        |sf6 = -nan
+        |""".stripMargin
+
+    val result = testSuccess(example).nodes
+    assert(result.length == 3)
+
+    // Cannot use `==` here since Double.NaN != Double.NaN
+    assert(result.forall {
+      case Node.Pair(_, Value.Real(v)) => v.equals(Double.NaN)
+      case _ => false
+    })
+  }
 }


### PR DESCRIPTION
- Parse floating point numbers containing fractional and exponent
  part
- Support infinity and NaN constants

Closes #11.