### PR TITLE
Embed: Forbid duplicate keys

### DIFF
--- a/shared/src/main/scala/toml/Embed.scala
+++ b/shared/src/main/scala/toml/Embed.scala
@@ -1,56 +1,91 @@
 package toml
 
 object Embed {
+  def addPair(stack: List[String],
+              result: Value.Tbl,
+              key: String,
+              value: Value
+             ): Either[Parse.Error, Value.Tbl] =
+    if (result.values.contains(key))
+      Left((stack :+ key) -> "Cannot redefine value")
+    else Right(Value.Tbl(result.values + (key -> value)))
+
+  def merge[T](values: List[T])(
+    f: (Value.Tbl, T) => Either[Parse.Error, Value.Tbl]
+  ): Either[Parse.Error, Value.Tbl] =
+    values.foldLeft(Right(Value.Tbl(Map())): Either[Parse.Error, Value.Tbl]) {
+      case (Left(m), _)          => Left(m)
+      case (Right(result), node) => f(result, node)
+    }
+
   def updateTable(value: Value.Tbl,
                   stack: List[String],
-                  insert: Map[String, Value]): Value.Tbl =
+                  trace: List[String],
+                  insert: List[(String, Value)]
+                 ): Either[Parse.Error, Value.Tbl] =
     stack match {
-      case Nil => Value.Tbl(insert)
+      case Nil =>
+        merge(insert) {
+          case (result, (key, value)) => addPair(trace, result, key, value)
+        }
+
       case stackHead :: stackTail =>
         val child =
           value.values.get(stackHead) match {
-            case Some(v: Value.Tbl) => updateTable(v, stackTail, insert)
+            case Some(v: Value.Tbl) => updateTable(v, stackTail, trace, insert)
             case Some(Value.Arr(init :+ last)) =>
-              Value.Arr(init :+ updateTable(
-                last.asInstanceOf[Value.Tbl], stackTail, insert))
-            case None => updateTable(Value.Tbl(Map.empty), stackTail, insert)
+              updateTable(
+                last.asInstanceOf[Value.Tbl], stackTail, trace, insert
+              ).right.map(v => Value.Arr(init :+ v))
+            case None => updateTable(Value.Tbl(Map()), stackTail, trace, insert)
           }
 
-        value.copy(values = value.values + (stackHead -> child))
+        child.right.map(c =>
+          value.copy(values = value.values + (stackHead -> c)))
     }
 
   def addArrayRow(value: Value,
                   stack: List[String],
-                  insert: Map[String, Value]): Value =
+                  trace: List[String],
+                  insert: List[(String, Value)]
+                 ): Either[Parse.Error, Value] =
     stack match {
       case Nil =>
-        value match {
-          case v: Value.Arr => v.copy(values = v.values :+ Value.Tbl(insert))
-          case _: Value.Tbl => Value.Arr(List(Value.Tbl(insert)))
+        merge(insert) {
+          case (result, (key, value)) => addPair(trace, result, key, value)
         }
+        .right.map(tbl =>
+          value match {
+            case v: Value.Arr => v.copy(values = v.values :+ tbl)
+            case _: Value.Tbl => Value.Arr(List(tbl))
+          })
 
       case stackHead :: stackTail =>
         value match {
           case Value.Arr(init :+ last) =>
-            Value.Arr(init :+ addArrayRow(last, stack, insert))
+            addArrayRow(last, stack, trace, insert)
+              .right
+              .map(v => Value.Arr(init :+ v))
 
           case v: Value.Tbl =>
-            val oldChild = v.values.getOrElse(stackHead, Value.Tbl(Map.empty))
-            val newChild = addArrayRow(oldChild, stackTail, insert)
-
-            v.copy(values = v.values + (stackHead -> newChild))
+            val oldChild = v.values.getOrElse(stackHead, Value.Tbl(Map()))
+            addArrayRow(oldChild, stackTail, trace, insert).right.map(
+              newChild => v.copy(values = v.values + (stackHead -> newChild)))
         }
     }
 
   /** Eliminates all [[Node]] instances, converting them to tables and arrays */
-  def root(root: Root): Value.Tbl =
-    root.nodes.foldLeft(Value.Tbl(Map.empty)) { (result, node) =>
+  def root(root: Root): Either[Parse.Error, Value.Tbl] =
+    merge(root.nodes) { case (result, node) =>
       node match {
         case Node.Pair(key, value) =>
-          result.copy(values = result.values + (key -> value))
+          addPair(List(), result, key, value)
         case Node.NamedArray(path, pairs) =>
-          addArrayRow(result, path, pairs).asInstanceOf[Value.Tbl]
-        case Node.NamedTable(path, pairs) => updateTable(result, path, pairs)
+          addArrayRow(result, path, path, pairs)
+            .right
+            .map(_.asInstanceOf[Value.Tbl])
+        case Node.NamedTable(path, pairs) =>
+          updateTable(result, path, path, pairs)
       }
     }
 }

--- a/shared/src/main/scala/toml/Generate.scala
+++ b/shared/src/main/scala/toml/Generate.scala
@@ -33,14 +33,10 @@ object Generate {
     case Node.Pair(k, v) => k + " = " + generate(v)
     case Node.NamedTable(ref, values) =>
       "[" + generateRef(ref) + "]\n" +
-      values.mapValues(generate(_)).map { case (k, v) =>
-        k + " = " + v
-      }.mkString("\n")
+      values.map { case (k, v) => k + " = " + generate(v) }.mkString("\n")
     case Node.NamedArray(ref, values) =>
       "[[" + generateRef(ref) + "]]\n" +
-       values.mapValues(generate(_)).map { case (k, v) =>
-         k + " = " + v
-       }.mkString("\n")
+       values.map { case (k, v) => k + " = " + generate(v) }.mkString("\n")
   }
 
   def generate(root: Root): String =

--- a/shared/src/main/scala/toml/Node.scala
+++ b/shared/src/main/scala/toml/Node.scala
@@ -6,11 +6,11 @@ sealed trait Node
 object Node {
   case class Pair(key: String, value: Value) extends Node
 
-  case class NamedTable(ref: List[String], values: Map[String, Value])
+  case class NamedTable(ref: List[String], values: List[(String, Value)])
     extends Node
 
   /** Reference to an array item */
-  case class NamedArray(ref: List[String], values: Map[String, Value])
+  case class NamedArray(ref: List[String], values: List[(String, Value)])
     extends Node
 }
 

--- a/shared/src/main/scala/toml/Parse.scala
+++ b/shared/src/main/scala/toml/Parse.scala
@@ -1,0 +1,8 @@
+package toml
+
+object Parse {
+  type Field    = String
+  type Address  = List[Field]
+  type Message  = String
+  type Error    = (Address, Message)
+}

--- a/shared/src/main/scala/toml/Rules.scala
+++ b/shared/src/main/scala/toml/Rules.scala
@@ -121,11 +121,11 @@ object Rules extends PlatformRules {
   val pairNode: Parser[Node.Pair] = pair.map { case (k, v) => Node.Pair(k, v) }
   val table: Parser[Node.NamedTable] =
     P(skip ~ tableDef ~ skip ~ pair.rep(sep = skip)).map { case (a, b) =>
-      Node.NamedTable(a.toList, b.toMap)
+      Node.NamedTable(a.toList, b.toList)
     }
   val tableArray: Parser[Node.NamedArray] =
     P(skip ~ tableArrayDef ~ skip ~ pair.rep(sep = skip)).map { case (a, b) =>
-      Node.NamedArray(a.toList, b.toMap)
+      Node.NamedArray(a.toList, b.toList)
     }
 
   lazy val elem: Parser[Value] = P {

--- a/shared/src/test/scala/toml/EmbedSpec.scala
+++ b/shared/src/test/scala/toml/EmbedSpec.scala
@@ -8,7 +8,7 @@ class EmbedSpec extends FunSuite {
   test("One pair") {
     val pair = """a = 1"""
     val node = Rules.root.parse(pair).get.value
-    assert(Embed.root(node) == Tbl(Map("a" -> Num(1))))
+    assert(Embed.root(node) == Right(Tbl(Map("a" -> Num(1)))))
   }
 
   test("Two pairs") {
@@ -17,8 +17,8 @@ class EmbedSpec extends FunSuite {
         |a = 1
       """.stripMargin
     val node2 = Rules.root.parse(pairs).get.value
-    assert(Embed.root(node2) == Tbl(Map(
-      "a" -> Num(1), "b" -> Num(2))))
+    assert(Embed.root(node2) == Right(Tbl(Map(
+      "a" -> Num(1), "b" -> Num(2)))))
   }
 
   test("Simple table") {
@@ -29,7 +29,7 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(table).get.value
     assert(Embed.root(node) ==
-      Tbl(Map("table" -> Tbl(Map("a" -> Num(1))))))
+      Right(Tbl(Map("table" -> Tbl(Map("a" -> Num(1)))))))
   }
 
   test("Pair and table") {
@@ -41,7 +41,7 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(table).get.value
     assert(Embed.root(node) ==
-      Tbl(Map("a" -> Num(1), "table" -> Tbl(Map("b" -> Num(2))))))
+      Right(Tbl(Map("a" -> Num(1), "table" -> Tbl(Map("b" -> Num(2)))))))
   }
 
   test("Nested table") {
@@ -52,9 +52,9 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(table).get.value
     assert(Embed.root(node) ==
-      Tbl(Map("table" ->
+      Right(Tbl(Map("table" ->
         Tbl(Map("table2" ->
-          Tbl(Map("value" -> Num(42))))))))
+          Tbl(Map("value" -> Num(42)))))))))
   }
 
   test("Two nested tables") {
@@ -67,10 +67,10 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(table).get.value
     assert(Embed.root(node) ==
-      Tbl(Map(
+      Right(Tbl(Map(
         "table" -> Tbl(Map(
           "table2" -> Tbl(Map("value" -> Num(23))),
-          "table3" -> Tbl(Map("value" -> Num(42))))))))
+          "table3" -> Tbl(Map("value" -> Num(42)))))))))
   }
 
   test("Empty nested tables") {
@@ -82,10 +82,10 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(table).get.value
     assert(Embed.root(node) ==
-      Tbl(Map(
+      Right(Tbl(Map(
         "table" -> Tbl(Map(
           "table2" -> Tbl(Map.empty),
-          "table3" -> Tbl(Map("value" -> Num(42))))))))
+          "table3" -> Tbl(Map("value" -> Num(42)))))))))
   }
 
 
@@ -98,11 +98,11 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
     val node = Rules.root.parse(tableList).get.value
     assert(Embed.root(node) ==
-      Tbl(Map(
+      Right(Tbl(Map(
         "points" -> Arr(List(
           Tbl(Map("x" -> Num(1), "y" -> Num(2), "z" -> Num(3))),
           Tbl(Map("x" -> Num(7), "y" -> Num(8), "z" -> Num(9))),
-          Tbl(Map("x" -> Num(2), "y" -> Num(4), "z" -> Num(8))))))))
+          Tbl(Map("x" -> Num(2), "y" -> Num(4), "z" -> Num(8)))))))))
   }
 
   test("Array") {
@@ -120,11 +120,11 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
 
     val node = Rules.root.parse(array).get.value
-    assert(Embed.root(node) == Tbl(Map(
+    assert(Embed.root(node) == Right(Tbl(Map(
       "products" -> Arr(List(
         Tbl(Map("name" -> Str("Hammer"), "sku" -> Num(738594937), "colour" -> Str("blue"))),
         Tbl(Map("name" -> Str("Nail")  , "sku" -> Num(284758393), "colour" -> Str("grey")))
-      )))))
+      ))))))
   }
 
   test("Array with empty items") {
@@ -143,12 +143,12 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
 
     val node = Rules.root.parse(array).get.value
-    assert(Embed.root(node) == Tbl(Map(
+    assert(Embed.root(node) == Right(Tbl(Map(
       "products" -> Arr(List(
         Tbl(Map("name" -> Str("Hammer"), "sku" -> Num(738594937))),
         Tbl(Map.empty),
         Tbl(Map("name" -> Str("Nail"), "sku" -> Num(284758393), "colour" -> Str("grey")))
-      )))))
+      ))))))
   }
 
   test("Nested array") {
@@ -175,7 +175,7 @@ class EmbedSpec extends FunSuite {
       """.stripMargin
 
     val node = Rules.root.parse(array).get.value
-    assert(Embed.root(node) == Tbl(Map(
+    assert(Embed.root(node) == Right(Tbl(Map(
       "fruit" -> Arr(List(
         Tbl(Map(
           "name" -> Str("apple"),
@@ -195,6 +195,6 @@ class EmbedSpec extends FunSuite {
           ))
         ))
       ))
-    )))
+    ))))
   }
 }

--- a/shared/src/test/scala/toml/GenerationSpec.scala
+++ b/shared/src/test/scala/toml/GenerationSpec.scala
@@ -1,7 +1,7 @@
 package toml
 
-import Value._
 import Node._
+import Value._
 
 import org.scalatest.FunSuite
 
@@ -10,7 +10,7 @@ class GenerationSpec extends FunSuite {
     val generated = Toml.generate(root)
     val parsed = Toml.parse(generated)
 
-    assert(parsed == Right(Embed.root(root)))
+    assert(parsed == Embed.root(root))
     assert(generated == expected)
   }
 
@@ -34,7 +34,7 @@ class GenerationSpec extends FunSuite {
   }
 
   test("Table") {
-    val root = Root(List(NamedTable(List("table"), Map("a" -> Num(1)))))
+    val root = Root(List(NamedTable(List("table"), List("a" -> Num(1)))))
 
     val table =
       """
@@ -46,7 +46,7 @@ class GenerationSpec extends FunSuite {
   }
 
   test("Escape table reference") {
-    val root = Root(List(NamedTable(List("a", "b 2"), Map("a" -> Num(1)))))
+    val root = Root(List(NamedTable(List("a", "b 2"), List("a" -> Num(1)))))
 
     val table =
       """
@@ -58,7 +58,7 @@ class GenerationSpec extends FunSuite {
   }
 
   test("Escape table reference (2)") {
-    val root = Root(List(NamedTable(List("a", "b\"c"), Map("a" -> Num(1)))))
+    val root = Root(List(NamedTable(List("a", "b\"c"), List("a" -> Num(1)))))
 
     val table =
       """
@@ -70,7 +70,7 @@ class GenerationSpec extends FunSuite {
   }
 
   test("Escape table reference (3)") {
-    val root = Root(List(NamedTable(List("a", "b.c"), Map("a" -> Num(1)))))
+    val root = Root(List(NamedTable(List("a", "b.c"), List("a" -> Num(1)))))
 
     val table =
       """
@@ -85,7 +85,7 @@ class GenerationSpec extends FunSuite {
     val root = Root(List(
       Pair("a", Num(1)),
       NamedTable(
-        List("table"), Map("b" -> Num(2)))))
+        List("table"), List("b" -> Num(2)))))
 
     val table =
       """
@@ -101,8 +101,8 @@ class GenerationSpec extends FunSuite {
   test("Two tables") {
     val root = Root(List(
       Pair("a", Num(1)),
-      NamedTable(List("table"), Map("b" -> Num(2))),
-      NamedTable(List("table2"), Map("c" -> Num(3)))))
+      NamedTable(List("table"), List("b" -> Num(2))),
+      NamedTable(List("table2"), List("c" -> Num(3)))))
 
     val table =
       """
@@ -120,7 +120,7 @@ class GenerationSpec extends FunSuite {
 
   test("Nested table") {
     val root = Root(List(
-      NamedTable(List("table", "table2"), Map("value" -> Num(42)))))
+      NamedTable(List("table", "table2"), List("value" -> Num(42)))))
 
     val table =
       """

--- a/shared/src/test/scala/toml/ParseSpec.scala
+++ b/shared/src/test/scala/toml/ParseSpec.scala
@@ -1,0 +1,37 @@
+package toml
+
+import Value._
+import Node._
+
+import org.scalatest.FunSuite
+
+class ParseSpec extends FunSuite {
+  test("Redefine value on root level") {
+    val toml =
+      """a = 23
+        |a = 42
+      """.stripMargin
+    val result = Toml.parse(toml)
+    assert(result == Left((List("a"), "Cannot redefine value")))
+  }
+
+  test("Redefine value in table") {
+    val toml =
+      """[a]
+        |b = 23
+        |b = 42
+      """.stripMargin
+    val result = Toml.parse(toml)
+    assert(result == Left((List("a", "b"), "Cannot redefine value")))
+  }
+
+  test("Redefine value in array") {
+    val toml =
+      """[[a]]
+        |b = 23
+        |b = 42
+      """.stripMargin
+    val result = Toml.parse(toml)
+    assert(result == Left((List("a", "b"), "Cannot redefine value")))
+  }
+}

--- a/shared/src/test/scala/toml/RulesSpec.scala
+++ b/shared/src/test/scala/toml/RulesSpec.scala
@@ -20,7 +20,7 @@ class RulesSpec extends FunSuite with Matchers {
   test("Strings in table headers") {
     assert(
       testSuccess("[ j . \"ʞ\" . 'l' ]") ==
-      Root(List(Node.NamedTable(List("j", "ʞ", "l"), Map.empty))))
+      Root(List(Node.NamedTable(List("j", "ʞ", "l"), List()))))
   }
 
   test("Parse quoted strings") {
@@ -91,7 +91,7 @@ class RulesSpec extends FunSuite with Matchers {
     assert(testSuccess(example) == Root(List(
       Node.NamedTable(
         List("a", "tes\"t"),
-        Map("b" -> Value.Num(42))))))
+        List("b" -> Value.Num(42))))))
   }
 
   test("Parse multi-line array with trailing commas") {


### PR DESCRIPTION
According to the TOML specification, "defining a key multiple times
is invalid". Return an error message with trace if a key is defined
more than once in the same scope.