### PR TITLE
Introduce language extension for multi-line inline tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,20 @@ scalaDeps = [
 ]
 ```
 
+#### Language Extensions
+toml-scala supports the following language extensions which are disabled by default:
+
+* [New lines and trailing commas in inline tables](https://github.com/toml-lang/toml/issues/516)
+
+To enable them, pass in a set of extensions to the `parse()` or `parseAs()` function as a second argument:
+
+```scala
+toml.Toml.parse("""key = {
+  a = 23,
+  b = 42,
+}""", Set(toml.Extension.MultiLineInlineTables))
+```
+
 ## Links
 * [ScalaDoc](https://www.javadoc.io/doc/tech.sparse/toml-scala_2.12/)
 

--- a/jvm/src/main/scala/toml/PlatformRules.scala
+++ b/jvm/src/main/scala/toml/PlatformRules.scala
@@ -4,7 +4,7 @@ import java.time._
 
 import scala.meta.internal.fastparse.all._
 
-trait PlatformRules { this: Rules.type =>
+trait PlatformRules { this: Rules =>
   private val TenPowers =
     List(1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000)
 

--- a/shared/src/test/scala/toml/CodecSpec.scala
+++ b/shared/src/test/scala/toml/CodecSpec.scala
@@ -62,7 +62,7 @@ class CodecSpec extends FunSuite {
     case class Pair(a: Int)
 
     val pair = """a = 1"""
-    assert(Toml.parseAs[Pair](pair) == Right(Pair(1)))
+    assert(Toml.parseAs[Pair](pair, Set()) == Right(Pair(1)))
 
     case class Pairs(a: Int, b: Int)
     val pairs =

--- a/shared/src/test/scala/toml/GeneratedSpec.scala
+++ b/shared/src/test/scala/toml/GeneratedSpec.scala
@@ -63,10 +63,10 @@ class GeneratedSpec extends PropSpec with PropertyChecks with Matchers {
     }
   }
 
-  property("Parse pairs (with `node` parser)") {
+  property("Parse pairs (with `root` parser)") {
     import Generators.Tables._
     forAll(pairGen) { s: String =>
-      shouldBeSuccess(Rules.node.parse(s))
+      shouldBeSuccess(Rules.root.parse(s))
     }
   }
 
@@ -80,14 +80,14 @@ class GeneratedSpec extends PropSpec with PropertyChecks with Matchers {
   property("Parse tables") {
     import Generators.Tables._
     forAll(tableGen) { s: String =>
-      shouldBeSuccess[Node.NamedTable](Rules.table.parse(s))
+      shouldBeSuccess[Node.NamedTable]((Rules.skip ~ Rules.table).parse(s))
     }
   }
 
-  property("Parse tables (with `node` parser)") {
+  property("Parse tables (with `root` parser)") {
     import Generators.Tables._
     forAll(tableGen) { s: String =>
-      shouldBeSuccess(Rules.node.parse(s))
+      shouldBeSuccess(Rules.root.parse(s))
     }
   }
 }

--- a/shared/src/test/scala/toml/ParseSpec.scala
+++ b/shared/src/test/scala/toml/ParseSpec.scala
@@ -6,6 +6,27 @@ import Node._
 import org.scalatest.FunSuite
 
 class ParseSpec extends FunSuite {
+  test("Parse strings") {
+    val toml =
+      """
+        |lines = '''
+        |
+        |The first newline is
+        |trimmed in raw strings.
+        |  All other whitespace
+        |  is preserved.
+        |'''
+        |""".stripMargin
+
+    val result = Toml.parse(toml)
+    assert(result == Right(Tbl(Map("lines" -> Value.Str(
+      "\n" +
+      "The first newline is\n" +
+      "trimmed in raw strings.\n" +
+      "  All other whitespace\n" +
+      "  is preserved.\n")))))
+  }
+
   test("Redefine value on root level") {
     val toml =
       """a = 23
@@ -33,5 +54,15 @@ class ParseSpec extends FunSuite {
       """.stripMargin
     val result = Toml.parse(toml)
     assert(result == Left((List("a", "b"), "Cannot redefine value")))
+  }
+
+  test("Extension: Parse inline tables with trailing comma") {
+    val result = Toml.parse("""key = {
+      a = 23,
+      b = 42,
+    }""", Set(Extension.MultiLineInlineTables))
+
+    assert(result == Right(Tbl(
+      Map("key" -> Tbl(Map("a" -> Num(23), "b" -> Num(42)))))))
   }
 }

--- a/shared/src/test/scala/toml/RulesSpec.scala
+++ b/shared/src/test/scala/toml/RulesSpec.scala
@@ -63,7 +63,41 @@ class RulesSpec extends FunSuite with Matchers {
     testSuccess(example)
   }
 
-  test("Parse inline tables") {
+  test("Parse inline tables (1)") {
+    val example =
+      """
+        |a = { name = "value", name2 = "value2" }
+        |b = { name = "value" }
+      """.stripMargin
+
+    testSuccess(example)
+  }
+
+  test("Extension: Parse inline tables with new line") {
+    // See https://github.com/toml-lang/toml/issues/516
+    val example =
+      """
+        |a = { name = "value", name2 = "value2" }
+        |b = { name = "value"
+        |    }
+      """.stripMargin
+
+    testFailure(example)
+    testSuccess(example, new Rules(Set(Extension.MultiLineInlineTables)))
+  }
+
+  test("Extension: Parse inline tables with trailing comma") {
+    val example =
+      """
+        |a = { name = "value", name2 = "value2" }
+        |b = { name = "value", }
+      """.stripMargin
+
+    testFailure(example)
+    testSuccess(example, new Rules(Set(Extension.MultiLineInlineTables)))
+  }
+
+  test("Extension: Parse inline tables with trailing comma and comment") {
     val example =
       """
         |a = { name = "value", name2 = "value2" }
@@ -71,7 +105,9 @@ class RulesSpec extends FunSuite with Matchers {
         |      # Trailing comma
         |    }
       """.stripMargin
-    testSuccess(example)
+
+    testFailure(example)
+    testSuccess(example, new Rules(Set(Extension.MultiLineInlineTables)))
   }
 
   test("Parse complex table keys") {

--- a/shared/src/test/scala/toml/TestHelpers.scala
+++ b/shared/src/test/scala/toml/TestHelpers.scala
@@ -8,14 +8,14 @@ import org.scalatest.Matchers
 object TestHelpers {
   import Matchers._
 
-  def testSuccess(example: String): Root =
-    Rules.root.parse(example) match {
+  def testSuccess(example: String, rules: Rules = Rules): Root =
+    rules.root.parse(example) match {
       case Success(v, _)    => v
       case f: Failure[_, _] => fail(s"Failed to parse `$example`: ${f.msg}")
     }
 
-  def testFailure(example: String): Unit =
-    Rules.root.parse(example) match {
+  def testFailure(example: String, rules: Rules = Rules): Unit =
+    rules.root.parse(example) match {
       case Success(_, _) => fail(s"Did not fail: $example")
       case _: Failure[_, _] =>
     }


### PR DESCRIPTION
To be standard compliant, an inline table should not span more than
one line or contain a trailing comma. Introduce a language extension
that must be enabled explicitly.