### PR TITLE
Update dependencies of sbt build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
-.idea
 
-.bloop
+/.idea/
+/.metals/
+.bloop/

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 val Scala2_11  = "2.11.12"
-val Scala2_12  = "2.12.8"
-val Scala2_13  = "2.13.0"
+val Scala2_12  = "2.12.10"
+val Scala2_13  = "2.13.1"
 val FastParse  = "1.0.1"
 val Shapeless  = "2.3.3"
-val ScalaCheck = "1.14.0"
+val ScalaCheck = "1.14.2"
 val ScalaTest  = "3.0.8"
 val ScalaTestNative = "3.2.0-SNAP10"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ logLevel := Level.Warn
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "0.6.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.28")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                   % "0.6.29")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.3.9")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,6 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"
+version in ThisBuild := {
+  import sys.process._
+  val version = Seq("git", "describe", "--tags").!!.trim.tail
+  println("[info] Setting version to: " + version)
+  version
+}


### PR DESCRIPTION
This only updates the dependencies of the sbt build since Bloop is incompatible with Scala.js 0.6.29.

See also https://github.com/scalacenter/bloop/issues/1062.