### PR TITLE
Rules: Allow spaces or tabs before commas in lists

### DIFF
--- a/shared/src/main/scala/toml/Rules.scala
+++ b/shared/src/main/scala/toml/Rules.scala
@@ -109,13 +109,13 @@ class Rules(extensions: Set[Extension]) extends PlatformRules {
   val pair: Parser[(String, Value)] =
     P(validKey ~ skipWs ~ "=" ~ skipWs ~ elem)
   val array: Parser[Value.Arr] =
-    P("[" ~ skip ~ elem.rep(sep = "," ~ skip) ~ ",".? ~ skip ~ "]")
+    P("[" ~ skip ~ elem.rep(sep = skip ~ "," ~ skip) ~ ",".? ~ skip ~ "]")
       .map(l => Value.Arr(l.toList))
   val inlineTable: Parser[Value.Tbl] =
     (if (extensions.contains(MultiLineInlineTables))
-      P("{" ~ skip ~ pair.rep(sep = "," ~ skip) ~ ",".? ~ skip ~ "}")
+      P("{" ~ skip ~ pair.rep(sep = skip ~ "," ~ skip) ~ ",".? ~ skip ~ "}")
      else
-      P("{" ~ skipWs ~ pair.rep(sep = "," ~ skipWs) ~ skipWs ~ "}")
+      P("{" ~ skipWs ~ pair.rep(sep = skipWs ~ "," ~ skipWs) ~ skipWs ~ "}")
     ).map(p => Value.Tbl(p.toMap))
 
   val tableIds: Parser[Seq[String]] =

--- a/shared/src/test/scala/toml/RulesSpec.scala
+++ b/shared/src/test/scala/toml/RulesSpec.scala
@@ -110,6 +110,12 @@ class RulesSpec extends FunSuite with Matchers {
     testSuccess(example, new Rules(Set(Extension.MultiLineInlineTables)))
   }
 
+  test("Parse list with spaces or tabs before commas") {
+    val tab = "\t"
+    val example = s"""dep = ["tech.sparse"   , "toml-scala"$tab, "0.2.2"]"""
+    testSuccess(example)
+  }
+
   test("Parse complex table keys") {
     val example =
       """[asdf."bit#"]


### PR DESCRIPTION
This fixes a regression introduced in 10a891ea6ebd87ee17ce5868824bb40d365b3455.